### PR TITLE
setup.py: Fixed syntax error by adding a comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
    name='scriptifier',
-   version="0.0.4"
+   version="0.0.4",
    description='A Python package that allows to run a function in a separated script, seamlessly.',
    license="MIT",
    long_description=long_description,


### PR DESCRIPTION
I saw your comment on our video: 

https://www.youtube.com/watch?v=U-aIPTS580s

Here is a fix for your setup.py file :)