### PR TITLE
Only trigger 1 workflow run per release

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,6 +1,8 @@
 name: Publish Python distributions to PyPI
 
-on: release
+on:
+  release:
+    types: [created]
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
I'm not 100% sure, but I think this will fix it.

Based on the default workflow, as can be seen here:
https://github.com/cfengine/cf-remote/blob/master/.github/workflows/python-publish.yml#L6-L8